### PR TITLE
[#27] Add basic CI/Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# Config file for automatic testing at travis-ci.org
+# This file will be regenerated if you run travis_pypi_setup.py
+
+language: python
+
+env:
+  - TOXENV=py34
+  - TOXENV=flake8
+  - TOXENV=isort
+  - TOXENV=manifest
+  - TOXENV=docs
+  - TOXENV=pep257
+
+before_install:
+  - pip install codecov
+
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install:
+  - pip install -U tox codecov
+
+# command to run tests, e.g. python setup.py test
+script:
+  - make test-all
+
+after_success:
+  - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ passenv =
 whitelist_externals = make
 
 [testenv:flake8]
-basepython = python3.5
+basepython = python3
 commands =
     flake8 setup.py armyimp/ tests/
 deps =
@@ -25,7 +25,7 @@ deps =
 skip_install = True
 
 [testenv:isort]
-basepython = python3.5
+basepython = python3
 commands =
     isort --check-only --recursive setup.py armyimp/ tests/
 deps =
@@ -33,7 +33,7 @@ deps =
 skip_install = True
 
 [testenv:manifest]
-basepython = python3.5
+basepython = python3
 commands =
     check-manifest -v
 deps =
@@ -41,7 +41,7 @@ deps =
 skip_install = True
 
 [testenv:pep257]
-basepython = python3.5
+basepython = python3
 commands =
     {toxinidir}/pep257.sh
 deps =
@@ -49,7 +49,7 @@ deps =
 skip_install = True
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3
 commands =
     pip install -r requirements/docs.pip
     make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:'-W'}


### PR DESCRIPTION
This PR brings basic support for Travis-CI.

Besides running our style checks the CI also runs the test suite against python 3.4.

Closes: #27 