### PR TITLE
[#68] Provide basic serialization for 'Unit' instances

### DIFF
--- a/armyimp/apps/w40k/serializers.py
+++ b/armyimp/apps/w40k/serializers.py
@@ -1,0 +1,58 @@
+from rest_framework import serializers
+
+from . import models
+
+
+class ItemInlineSerializer(serializers.ModelSerializer):
+    """
+    Inline serializer for the ``Item`` model.
+
+    This class is not suitable for a complete representation of instances.
+    Its use case is to include just the relevant information to its parent
+    serializer.
+    """
+
+    class Meta:
+        model = models.Item
+        fields = ('pk', 'name')
+
+
+class ItemSlotInlineSerializer(serializers.ModelSerializer):
+    """
+    Inline serializer for the ``ItemSlot`` model.
+
+    This class is not suitable for a complete representation of instances.
+    Its use case is to include just the relevant information to its parent
+    serializer.
+    """
+
+    default = ItemInlineSerializer()
+
+    class Meta:
+        model = models.ItemSlot
+        fields = ('pk', 'default')
+
+
+class UnitModelInlineSerializer(serializers.ModelSerializer):
+    """Inline serializer for the ``UnitModel`` model.
+
+    This class is not suitable for a complete representation of instances.
+    Its use case is to include just the relevant information to its parent
+    serializer.
+    """
+
+    item_slots = ItemSlotInlineSerializer(many=True)
+
+    class Meta:
+        model = models.UnitModel
+        fields = ('pk', 'name_suffix', 'profile', 'min_amount', 'max_amount', 'item_slots')
+
+
+class UnitSerializer(serializers.ModelSerializer):
+    """Serializer for the ``Unit`` model."""
+
+    models = UnitModelInlineSerializer(many=True)
+
+    class Meta:
+        model = models.Unit
+        fields = ('pk', 'name', 'models')

--- a/armyimp/apps/w40k/urls.py
+++ b/armyimp/apps/w40k/urls.py
@@ -1,13 +1,18 @@
-from django.urls import path
+from django.urls import include, path
 from django.views import generic as generic_views
+from rest_framework import routers
 
-from . import views
+from . import views, viewsets
 
 app_name = 'w40k'
+
+router = routers.DefaultRouter()
+router.register(r'units', viewsets.UnitViewSet)
 
 urlpatterns = [
     path(r'', generic_views.TemplateView.as_view(template_name='w40k/landing_page.html'),
          name='landing_page'),
+    path(r'api/', include(router.urls)),
     path(r'army_unit/', views.ArmyUnitListView.as_view(), name='army_unit_list'),
     path(r'army_unit/create/', views.ArmyUnitCreateView.as_view(), name='army_unit_create'),
     path(r'army_unit/<int:pk>/', views.ArmyUnitDetailView.as_view(), name='army_unit_detail'),

--- a/armyimp/apps/w40k/views.py
+++ b/armyimp/apps/w40k/views.py
@@ -27,7 +27,7 @@ class ArmyUnitCreateView(generic_views.CreateView):
     def post(self, request, *args, **kwargs):
         """Use the POST context to fetch the unit."""
         self.add_unit(request.POST)
-        return super().get(request, *args, **kwargs)
+        return super().post(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         """

--- a/armyimp/apps/w40k/viewsets.py
+++ b/armyimp/apps/w40k/viewsets.py
@@ -1,0 +1,10 @@
+from rest_framework import viewsets
+
+from . import models, serializers
+
+
+class UnitViewSet(viewsets.ModelViewSet):
+    """Viewset for ``Unit`` instances."""
+
+    queryset = models.Unit.objects.all()
+    serializer_class = serializers.UnitSerializer

--- a/armyimp/config/settings/common.py
+++ b/armyimp/config/settings/common.py
@@ -187,6 +187,7 @@ class Common(Configuration):
         'django.contrib.admin',
         'django.contrib.admindocs',
         'crispy_forms',
+        'rest_framework',
         'rules.apps.AutodiscoverRulesConfig',
         'nested_admin',
         'armyimp.apps.w40k.apps.W40KConfig',
@@ -207,3 +208,11 @@ class Common(Configuration):
     DEFAULT_FROM_EMAIL = values.EmailValue('elbenfreund@DenkenInEchtzeit.net')
 
     SERVER_EMAIL = DEFAULT_FROM_EMAIL
+
+    REST_FRAMEWORK = {
+        # Use Django's standard `django.contrib.auth` permissions,
+        # or allow read-only access for unauthenticated users.
+        'DEFAULT_PERMISSION_CLASSES': [
+            'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+        ]
+    }

--- a/armyimp/config/urls.py
+++ b/armyimp/config/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     url(r'^grappelli/', include('grappelli.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^nested_admin/', include('nested_admin.urls')),
+    url(r'^api-auth/', include('rest_framework.urls')),
     url(r'w40k/', include(w40k_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ ignore=E128
 line_length = 99
 not_skip = __init__.py
 known_first_party = armyimp,tests
-known_third_party = braces,configurations,coverage,crispy_forms,dj_database_url,django,envdir,factory,factory_boy,faker,fauxfactory,freezegun,grappelli,nested_admin,psycopg2,pytest,pytest_factoryboy,six
+known_third_party = braces,configurations,coverage,crispy_forms,dj_database_url,django,envdir,factory,factory_boy,faker,fauxfactory,freezegun,grappelli,nested_admin,psycopg2,pytest,pytest_factoryboy,rest_framework,six
 skip = manage.py,migrations,wsgi.py
 
 [pep257]

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requires = [
     'django-grappelli==2.11.1',
     'django-model-utils==3.1.1',
     'django-nested-admin==3.0.21',
+    'djangorestframework==3.7.7',
     'envdir==0.7',
     'psycopg2-binary==2.7.4',
     'pytz==2018.3',

--- a/tests/w40k/test_views.py
+++ b/tests/w40k/test_views.py
@@ -61,6 +61,15 @@ class TestArmyUnitCreateView():
         context_formset = response.context['army_model_formset']
         assert context_formset.extra == unit.models_min
 
+    def test_post_valid_data_creates_instances(self, client, unit, army_unit_data):
+        """Test that passing valid data creates the expected instances."""
+        old_army_unit_count = models.ArmyUnit.objects.all().count()
+        old_army_models_count = models.ArmyUnit.objects.all().count()
+        response = client.post(reverse('w40k:army_unit_create'), army_unit_data)
+        assert response.status_code == 302
+        assert models.ArmyUnit.objects.all().count() == old_army_unit_count + 1
+        assert models.ArmyModel.objects.all().count() == old_army_models_count + unit.models_min
+
     def test_post_missing_army_model_model(self, client, unit, army_unit_data):
         """Test that a formset form missing a value for ``model`` will raise an error."""
         model_count = unit.models_min


### PR DESCRIPTION
This merge introduces the ``django-rest-framework`` to the project. 
Based on this we provide a simple Serializer for ``Unit`` instances accompanied by some rudimentary *InlineSerializer* classes that handle relevant related objects.

Also includes bugfix for #67 

Closes: #67, Closes #67